### PR TITLE
Parse pattern to get method, host, and path

### DIFF
--- a/http.go
+++ b/http.go
@@ -1,0 +1,7 @@
+package http
+
+import "golang.org/x/net/http/httpguts"
+
+func isNotToken(r rune) bool {
+	return !httpguts.IsTokenRune(r)
+}

--- a/pattern.go
+++ b/pattern.go
@@ -1,0 +1,83 @@
+// Copyright 2023 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Patterns for ServeMux routing.
+
+package http
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// A pattern is something that can be matched against an HTTP request.
+// It has an optional method, an optional host, and a path.
+type pattern struct {
+	str    string // original string
+	method string
+	host   string
+}
+
+// parsePattern parses a string into a Pattern.
+// The string's syntax is
+//
+//	[METHOD] [HOST]/[PATH]
+//
+// where:
+//   - METHOD is an HTTP method
+//   - HOST is a hostname
+//   - PATH consists of slash-separated segments, where each segment is either
+//     a literal or a wildcard of the form "{name}", "{name...}", or "{$}".
+//
+// METHOD, HOST and PATH are all optional; that is, the string can be "/".
+// If METHOD is present, it must be followed by at least one space or tab.
+// Wildcard names must be valid Go identifiers.
+// The "{$}" and "{name...}" wildcard must occur at the end of PATH.
+// PATH may end with a '/'.
+// Wildcard names in a path must be distinct.
+func parsePattern(s string) (_ *pattern, err error) {
+	if len(s) == 0 {
+		return nil, errors.New("empty pattern")
+	}
+	off := 0 // offset into string
+	defer func() {
+		if err != nil {
+			err = fmt.Errorf("at offset %d: %w", off, err)
+		}
+	}()
+
+	method, rest, found := s, "", false
+	if i := strings.IndexAny(s, " \t"); i >= 0 {
+		method, rest, found = s[:i], strings.TrimLeft(s[i+1:], " \t"), true
+	}
+	if !found {
+		rest = method
+		method = ""
+	}
+	if method != "" && !validMethod(method) {
+		return nil, fmt.Errorf("invalid method %q", method)
+	}
+	p := &pattern{str: s, method: method}
+
+	if found {
+		off = len(method) + 1
+	}
+	i := strings.IndexByte(rest, '/')
+	if i < 0 {
+		return nil, errors.New("host/path missing /")
+	}
+	p.host = rest[:i]
+	rest = rest[i:]
+	if j := strings.IndexByte(p.host, '{'); j >= 0 {
+		off += j
+		return nil, errors.New("host contains '{' (missing initial '/'?)")
+	}
+	// At this point, rest is the path.
+	off += i
+
+	// TODO: https://github.com/ryuju0911/http-pkg/issues/8
+	// - Parse path to get slash-separated segments.
+	return p, nil
+}

--- a/pattern_test.go
+++ b/pattern_test.go
@@ -1,0 +1,49 @@
+// Copyright 2023 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package http
+
+import "testing"
+
+func TestParsePattern(t *testing.T) {
+	for _, test := range []struct {
+		in   string
+		want pattern
+	}{
+		{"/", pattern{}},
+		{
+			"example.com/",
+			pattern{host: "example.com"},
+		},
+		{
+			"GET /",
+			pattern{method: "GET"},
+		},
+		{
+			"POST example.com/foo/{w}",
+			pattern{
+				method: "POST",
+				host:   "example.com",
+			},
+		},
+	} {
+		got := mustParsePattern(t, test.in)
+		if !got.equal(&test.want) {
+			t.Errorf("%q:\ngot  %#v\nwant %#v", test.in, got, &test.want)
+		}
+	}
+}
+
+func (p1 *pattern) equal(p2 *pattern) bool {
+	return p1.method == p2.method && p1.host == p2.host
+}
+
+func mustParsePattern(tb testing.TB, s string) *pattern {
+	tb.Helper()
+	p, err := parsePattern(s)
+	if err != nil {
+		tb.Fatal(err)
+	}
+	return p
+}

--- a/request.go
+++ b/request.go
@@ -1,0 +1,34 @@
+// Copyright 2009 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// HTTP Request reading and parsing.
+
+package http
+
+import "strings"
+
+// A Request represents an HTTP request received by a server
+// or to be sent by a client.
+//
+// The field semantics differ slightly between client and server
+// usage. In addition to the notes on the fields below, see the
+// documentation for [Request.Write] and [RoundTripper].
+type Request struct{}
+
+func validMethod(method string) bool {
+	/*
+	     Method         = "OPTIONS"                ; Section 9.2
+	                    | "GET"                    ; Section 9.3
+	                    | "HEAD"                   ; Section 9.4
+	                    | "POST"                   ; Section 9.5
+	                    | "PUT"                    ; Section 9.6
+	                    | "DELETE"                 ; Section 9.7
+	                    | "TRACE"                  ; Section 9.8
+	                    | "CONNECT"                ; Section 9.9
+	                    | extension-method
+	   extension-method = token
+	     token          = 1*<any CHAR except CTLs or separators>
+	*/
+	return len(method) > 0 && strings.IndexFunc(method, isNotToken) == -1
+}


### PR DESCRIPTION
## Issue Number
#7 

## Implementation Summary  
This PR implements the `parsePattern` function, which parses a pattern to extract the method, host, and path.  
Before registering a handler, the server uses this function to parse the provided pattern. The syntax for the pattern is `[METHOD [HOST]/[PATH]]`, where:  
- **METHOD**: Represents an HTTP method.  
- **HOST**: Represents a hostname.  
- **PATH**: Consists of slash-separated segments, with each segment being either a literal or a wildcard in the form `{name}`, `{name...}`, or `{$}`.  

You can see the detailed syntax in the Handler Registration and Routing Logic section of [the design doc](https://docs.google.com/document/d/1LdstLJEXSpGLXnUdCfw4LzxNVIol96_-gMtIRTf7gVE/edit?usp=sharing).

## Scope of Impact  
This PR focuses only on parsing the method and host, excluding the path, as parsing the path involves additional processing.  

## Particular points to check
Please check if the implementation scope is appropriate.

## Test
`pattern_test.go` tests if the `parePattern` function can correctly get the host and method.

## Schedule
1/10
