### PR TITLE
Parse path to get slash-separated segments

### DIFF
--- a/pattern_test.go
+++ b/pattern_test.go
@@ -4,28 +4,76 @@
 
 package http
 
-import "testing"
+import (
+	"slices"
+	"strings"
+	"testing"
+)
 
 func TestParsePattern(t *testing.T) {
+	lit := func(name string) segment {
+		return segment{s: name}
+	}
+
+	wild := func(name string) segment {
+		return segment{s: name, wild: true}
+	}
+
+	multi := func(name string) segment {
+		s := wild(name)
+		s.multi = true
+		return s
+	}
+
 	for _, test := range []struct {
 		in   string
 		want pattern
 	}{
-		{"/", pattern{}},
+		{"/", pattern{segments: []segment{multi("")}}},
+		{"/a", pattern{segments: []segment{lit("a")}}},
+		{
+			"/a/",
+			pattern{segments: []segment{lit("a"), multi("")}},
+		},
+		{"/path/to/something", pattern{segments: []segment{
+			lit("path"), lit("to"), lit("something"),
+		}}},
 		{
 			"example.com/",
-			pattern{host: "example.com"},
+			pattern{host: "example.com", segments: []segment{multi("")}},
 		},
 		{
 			"GET /",
-			pattern{method: "GET"},
+			pattern{method: "GET", segments: []segment{multi("")}},
 		},
 		{
 			"POST example.com/foo/{w}",
 			pattern{
-				method: "POST",
-				host:   "example.com",
+				method:   "POST",
+				host:     "example.com",
+				segments: []segment{lit("foo")},
 			},
+		},
+		{
+			"//",
+			pattern{segments: []segment{lit(""), multi("")}},
+		},
+		{
+			"/foo///./../bar",
+			pattern{segments: []segment{lit("foo"), lit(""), lit(""), lit("."), lit(".."), lit("bar")}},
+		},
+		{
+			"a.com/foo//",
+			pattern{host: "a.com", segments: []segment{lit("foo"), lit(""), multi("")}},
+		},
+		{
+			"/%61%62/%7b/%",
+			pattern{segments: []segment{lit("ab"), lit("{"), lit("%")}},
+		},
+		// Allow multiple spaces matching regexp '[ \t]+' between method and path.
+		{
+			"GET\t  /",
+			pattern{method: "GET", segments: []segment{multi("")}},
 		},
 	} {
 		got := mustParsePattern(t, test.in)
@@ -35,8 +83,27 @@ func TestParsePattern(t *testing.T) {
 	}
 }
 
+func TestParsePatternError(t *testing.T) {
+	for _, test := range []struct {
+		in       string
+		contains string
+	}{
+		{"", "empty pattern"},
+		{"A=B /", "at offset 0: invalid method"},
+		{" ", "at offset 1: host/path missing /"},
+		{"{a}/b", "at offset 0: host contains '{' (missing initial '/'?)"},
+		{"GET //", "at offset 4: non-CONNECT pattern with unclean path"},
+	} {
+		_, err := parsePattern(test.in)
+		if err == nil || !strings.Contains(err.Error(), test.contains) {
+			t.Errorf("%q:\ngot %v, want error containing %q", test.in, err, test.contains)
+		}
+	}
+}
+
 func (p1 *pattern) equal(p2 *pattern) bool {
-	return p1.method == p2.method && p1.host == p2.host
+	return p1.method == p2.method && p1.host == p2.host &&
+		slices.Equal(p1.segments, p2.segments)
 }
 
 func mustParsePattern(tb testing.TB, s string) *pattern {

--- a/server.go
+++ b/server.go
@@ -9,6 +9,8 @@ package http
 import (
 	"errors"
 	"fmt"
+	"path"
+	"strings"
 )
 
 // A Handler responds to an HTTP request.
@@ -179,6 +181,28 @@ type ServeMux struct{}
 var DefaultServeMux = &defaultServeMux
 
 var defaultServeMux ServeMux
+
+// cleanPath returns the canonical path for p, eliminating . and .. elements.
+func cleanPath(p string) string {
+	if p == "" {
+		return "/"
+	}
+	if p[0] != '/' {
+		p = "/" + p
+	}
+	np := path.Clean(p)
+	// path.Clean removes trailing slash except for root;
+	// put the trailing slash back if necessary.
+	if p[len(p)-1] == '/' && np != "/" {
+		// Fast path for common case of p being the string we want:
+		if len(p) == len(np)+1 && strings.HasPrefix(p, np) {
+			np = p
+		} else {
+			np += "/"
+		}
+	}
+	return np
+}
 
 // HandleFunc registers the handler function for the given pattern in [DefaultServeMux].
 // The documentation for [ServeMux] explains how patterns are matched.

--- a/server_test.go
+++ b/server_test.go
@@ -1,0 +1,21 @@
+package http
+
+import "testing"
+
+func TestCleanPath(t *testing.T) {
+	for _, test := range []struct {
+		in, want string
+	}{
+		{"//", "/"},
+		{"/x", "/x"},
+		{"//x", "/x"},
+		{"x//", "/x/"},
+		{"a//b/////c", "/a/b/c"},
+		{"/foo/../bar/./..//baz", "/baz"},
+	} {
+		got := cleanPath(test.in)
+		if got != test.want {
+			t.Errorf("%s: got %q, want %q", test.in, got, test.want)
+		}
+	}
+}


### PR DESCRIPTION
## Issue Number
#8 

## Implementation Summary
This PR enables the `parsePattern` function to extract slash-separated segments from a path after destructuring a pattern into method, host, and path.
This PR focuses only on literals, not wildcards, as parsing wildcards involves additional processing.

## Scope of Impact
The `parsePattern` function is executed when a handler is registered.

## Particular points to check
I added a "ServeMux" section to the [design doc](https://docs.google.com/document/d/1LdstLJEXSpGLXnUdCfw4LzxNVIol96_-gMtIRTf7gVE/edit?usp=sharing) because I noticed some unclear aspects, such as missing comments or code that is difficult to understand.
Please check if it provides helpful information for readers to understand the code.

## Test
Some test cases were added to the `parse_test.go`

## Schedule
1/17

## References
- [Original code](https://github.com/golang/go/blob/master/src/net/http/pattern.go#L84)
